### PR TITLE
Movement Refactor

### DIFF
--- a/Scripts/Player.gd
+++ b/Scripts/Player.gd
@@ -35,13 +35,42 @@ func _ready():
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 
 func _input(event):
-	if event is InputEventMouseButton:
-		# Right click to move
-		if event.button_index == MOUSE_BUTTON_RIGHT:
-			move_action(event, true)
+	if event is InputEventMouseMotion:
+		try_move(event,false)
+		return
+
+	if Input.is_action_just_released("hero_attack_move") or Input.is_action_just_released("hero_move"):
+		place_move_marker(camera_to_mouse_raycast(event.position).position)
+
+	if not (Input.is_action_pressed("hero_attack_move") or Input.is_action_pressed("hero_move")):
+		move_state = MovingState.NONE
+		return
+
+	if Input.is_action_just_pressed("hero_attack_move"):
+		move_state = MovingState.ATTACK_MOVING
+		try_move(event, true)
+		return
+	
+	if Input.is_action_just_pressed("hero_move"):
+		move_state = MovingState.MOVING
+		try_move(event, true)
+
+
+
+	pass
 			
 func _on_camera_setting_changed():
 	Spring_Arm.spring_length = clamp(Spring_Arm.spring_length, Config.min_zoom, Config.max_zoom)
+
+
+func try_move(event, show_particle_effect : bool):
+	if move_state == MovingState.ATTACK_MOVING:
+		attack_move_action(event, show_particle_effect)
+		return
+	
+	if move_state == MovingState.MOVING:
+		move_action(event, show_particle_effect)
+		return
 
 func move_action(event, show_particle_effect : bool):
 	var result = camera_to_mouse_raycast(event.position)
@@ -66,7 +95,7 @@ func move_action(event, show_particle_effect : bool):
 
 
 func attack_move_action(event, show_particle_effect : bool):
-	pass
+	move_action(event, show_particle_effect)
 
 
 func place_move_marker(location : Vector3):
@@ -75,7 +104,7 @@ func place_move_marker(location : Vector3):
 	get_node("/root").add_child(marker);
 	
 
-func camera_to_mouse_raycast(target_position) -> Dictionary:
+func camera_to_mouse_raycast(target_position : Vector2) -> Dictionary:
 	var from = Camera.project_ray_origin(target_position)
 	var to = from + Camera.project_ray_normal(target_position) * 1000
 	

--- a/Scripts/Player.gd
+++ b/Scripts/Player.gd
@@ -40,7 +40,9 @@ func _input(event):
 		return
 
 	if Input.is_action_just_released("hero_attack_move") or Input.is_action_just_released("hero_move"):
-		place_move_marker(camera_to_mouse_raycast(event.position).position)
+		var raycast = camera_to_mouse_raycast(event.position)
+		if not raycast.is_empty:
+			place_move_marker(raycast.position)
 
 	if not (Input.is_action_pressed("hero_attack_move") or Input.is_action_pressed("hero_move")):
 		move_state = MovingState.NONE

--- a/Scripts/Player.gd
+++ b/Scripts/Player.gd
@@ -38,12 +38,12 @@ func _input(event):
 	if event is InputEventMouseButton:
 		# Right click to move
 		if event.button_index == MOUSE_BUTTON_RIGHT:
-			move_action(event)
+			move_action(event, true)
 			
 func _on_camera_setting_changed():
 	Spring_Arm.spring_length = clamp(Spring_Arm.spring_length, Config.min_zoom, Config.max_zoom)
 
-func move_action(event):
+func move_action(event, show_particle_effect : bool):
 	var from = Camera.project_ray_origin(event.position)
 	var to = from + Camera.project_ray_normal(event.position) * 1000
 	
@@ -53,9 +53,10 @@ func move_action(event):
 	# Move
 	if result and result.collider.is_in_group("ground"):
 		result.position.y += 1;
-		var marker = MoveMarker.instantiate()
-		marker.position = result.position
-		get_node("/root").add_child(marker);
+		if show_particle_effect:
+			var marker = MoveMarker.instantiate()
+			marker.position = result.position
+			get_node("/root").add_child(marker);
 		ServerListener.rpc_id(get_multiplayer_authority(), "MoveTo", result.position)
 		#Player.MoveTo(result.position);
 	# Attack
@@ -70,7 +71,7 @@ func move_action(event):
 		var group = 0
 		ServerListener.rpc_id(get_multiplayer_authority(), "Target", result.collider.pid, group)
 
-func attack_move_action(event):
+func attack_move_action(event, show_particle_effect : bool):
 	pass
 
 func _process(delta):

--- a/Scripts/Player.gd
+++ b/Scripts/Player.gd
@@ -1,5 +1,12 @@
 extends Node3D
 
+enum MovingState {
+	NONE,
+	MOVING,
+	ATTACK_MOVING,
+}
+
+
 @export var cur_zoom: int;
 
 @export var min_x: int;
@@ -11,6 +18,8 @@ extends Node3D
 @export var Camera: Camera3D;
 @export var MoveMarker: PackedScene;
 @export var ServerListener: Node;
+
+var move_state : MovingState
 
 var UI: Script;
 

--- a/Scripts/Player.gd
+++ b/Scripts/Player.gd
@@ -44,12 +44,7 @@ func _on_camera_setting_changed():
 	Spring_Arm.spring_length = clamp(Spring_Arm.spring_length, Config.min_zoom, Config.max_zoom)
 
 func move_action(event, show_particle_effect : bool):
-	var from = Camera.project_ray_origin(event.position)
-	var to = from + Camera.project_ray_normal(event.position) * 1000
-	
-	var space = get_world_3d().direct_space_state
-	var params = PhysicsRayQueryParameters3D.create(from, to)
-	var result = space.intersect_ray(params)
+	var result = camera_to_mouse_raycast(event.position)
 	# Move
 	if result and result.collider.is_in_group("ground"):
 		result.position.y += 1;
@@ -79,6 +74,14 @@ func place_move_marker(location : Vector3):
 	marker.position = location
 	get_node("/root").add_child(marker);
 	
+
+func camera_to_mouse_raycast(target_position) -> Dictionary:
+	var from = Camera.project_ray_origin(target_position)
+	var to = from + Camera.project_ray_normal(target_position) * 1000
+	
+	var space = get_world_3d().direct_space_state
+	var params = PhysicsRayQueryParameters3D.create(from, to)
+	return space.intersect_ray(params)
 
 
 func _process(delta):

--- a/Scripts/Player.gd
+++ b/Scripts/Player.gd
@@ -54,9 +54,7 @@ func move_action(event, show_particle_effect : bool):
 	if result and result.collider.is_in_group("ground"):
 		result.position.y += 1;
 		if show_particle_effect:
-			var marker = MoveMarker.instantiate()
-			marker.position = result.position
-			get_node("/root").add_child(marker);
+			place_move_marker(result.position)
 		ServerListener.rpc_id(get_multiplayer_authority(), "MoveTo", result.position)
 		#Player.MoveTo(result.position);
 	# Attack
@@ -71,8 +69,17 @@ func move_action(event, show_particle_effect : bool):
 		var group = 0
 		ServerListener.rpc_id(get_multiplayer_authority(), "Target", result.collider.pid, group)
 
+
 func attack_move_action(event, show_particle_effect : bool):
 	pass
+
+
+func place_move_marker(location : Vector3):
+	var marker = MoveMarker.instantiate()
+	marker.position = location
+	get_node("/root").add_child(marker);
+	
+
 
 func _process(delta):
 	# ignore all inputs when changing configs since that is annoying

--- a/Scripts/Player.gd
+++ b/Scripts/Player.gd
@@ -38,12 +38,12 @@ func _input(event):
 	if event is InputEventMouseButton:
 		# Right click to move
 		if event.button_index == MOUSE_BUTTON_RIGHT:
-			Action(event)
+			move_action(event)
 			
 func _on_camera_setting_changed():
 	Spring_Arm.spring_length = clamp(Spring_Arm.spring_length, Config.min_zoom, Config.max_zoom)
 
-func Action(event):
+func move_action(event):
 	var from = Camera.project_ray_origin(event.position)
 	var to = from + Camera.project_ray_normal(event.position) * 1000
 	
@@ -69,6 +69,9 @@ func Action(event):
 	if result and result.collider is CharacterBody3D:
 		var group = 0
 		ServerListener.rpc_id(get_multiplayer_authority(), "Target", result.collider.pid, group)
+
+func attack_move_action(event):
+	pass
 
 func _process(delta):
 	# ignore all inputs when changing configs since that is annoying

--- a/project.godot
+++ b/project.godot
@@ -80,3 +80,13 @@ toggle_maximize={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194342,"key_label":0,"unicode":0,"echo":false,"script":null)
 ]
 }
+hero_attack_move={
+"deadzone": 0.5,
+"events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":1,"canceled":false,"pressed":false,"double_click":false,"script":null)
+]
+}
+hero_move={
+"deadzone": 0.5,
+"events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":2,"canceled":false,"pressed":false,"double_click":false,"script":null)
+]
+}


### PR DESCRIPTION
I rewrote some of the movement code in `Player.gd` such that the hero will follow the mouse while right click is held down. This is similar to what happens in League, and makes adjusting movement feel more natural.

There is also a separate input mapping and function for attack-moving. It currently just calls the regular move function, but in future it could be used for alternate movement. This is also similar to how League does it.

It feels a bit too smooth in my opinion. I can fix that if other people feel the same way. It also floods the console with debug messages because of how often it sends packets to the server.

Also some style guide formatting in `Player.gd`.