### PR TITLE
Reintroducing Dragging

### DIFF
--- a/Scripts/player.gd
+++ b/Scripts/player.gd
@@ -8,6 +8,8 @@ extends Node3D
 
 const MoveMarker: PackedScene = preload ("res://effects/move_marker.tscn")
 
+var dragging = false
+
 #@export var player := 1:
 	#set(id):
 		#player = id
@@ -19,11 +21,22 @@ func _ready():
 	spring_arm.spring_length = Config.max_zoom
 	Config.camera_property_changed.connect(_on_camera_setting_changed)
 
+
 func _input(event):
 	if event is InputEventMouseButton:
-		# Right click to move
 		if event.button_index == MOUSE_BUTTON_RIGHT:
-			player_action(event)
+			# Start dragging
+			if not dragging and event.is_pressed():
+				dragging = true
+	
+		# Stop dragging if mouse is released
+		if dragging and not event.is_pressed():
+			dragging = false
+		player_action(event)  # For single clicks
+	
+	if event is InputEventMouseMotion and dragging:
+		player_action(event)  # For dragging
+
 
 func get_target_position(pid: int) -> Vector3:
 	var champs = $"../Champions".get_children()

--- a/Scripts/player.gd
+++ b/Scripts/player.gd
@@ -24,15 +24,16 @@ func _ready():
 
 func _input(event):
 	if event is InputEventMouseButton:
+		# Right click to move
 		if event.button_index == MOUSE_BUTTON_RIGHT:
 			# Start dragging
+			player_action(event)  # For single clicks
 			if not dragging and event.is_pressed():
 				dragging = true
 	
 		# Stop dragging if mouse is released
 		if dragging and not event.is_pressed():
 			dragging = false
-		player_action(event)  # For single clicks
 	
 	if event is InputEventMouseMotion and dragging:
 		player_action(event)  # For dragging

--- a/UI/ui.gd
+++ b/UI/ui.gd
@@ -18,12 +18,9 @@ func _process(delta):
 			settings_menu.hide()
 		else:
 			settings_menu.show()
-<<<<<<< HEAD
-=======
 	
 	if stats:
 		check_stats()
->>>>>>> 5818c33 (Adjust so TestUI Doesn't Also Check Stats)
 
 func check_stats():
 	var pid = multiplayer.get_unique_id()

--- a/UI/ui.gd
+++ b/UI/ui.gd
@@ -18,6 +18,12 @@ func _process(delta):
 			settings_menu.hide()
 		else:
 			settings_menu.show()
+<<<<<<< HEAD
+=======
+	
+	if stats:
+		check_stats()
+>>>>>>> 5818c33 (Adjust so TestUI Doesn't Also Check Stats)
 
 func check_stats():
 	var pid = multiplayer.get_unique_id()


### PR DESCRIPTION
I noticed you can't move your character through dragging with right click anymore, this reintroduces it. Also stops TestUI from checking for stats, something that UI is meant to do.