### PR TITLE
Turret, Ability and Minion Fixes

### DIFF
--- a/effects/abilities/arrow_storm.gd
+++ b/effects/abilities/arrow_storm.gd
@@ -22,7 +22,7 @@ func _process(delta):
 		ticktime_left = ticktime
 		var bodies = get_overlapping_bodies()
 		for body in bodies:
-			if body is CharacterBody3D && body.team != team:
+			if body is CharacterBody3D && body.team != team and !body.is_in_group("Objective"):
 				body.take_damage(damage)
 	if !p.emitting:
 		queue_free()

--- a/effects/abilities/skilled_shot.gd
+++ b/effects/abilities/skilled_shot.gd
@@ -17,7 +17,7 @@ func _process(delta):
 	position = position + direction * delta
 	var bodies = get_overlapping_bodies()
 	for body in bodies:
-		if body is CharacterBody3D && body.team != team:
+		if body is CharacterBody3D && body.team != team and !body.is_in_group("Objective"):
 			body.take_damage(damage)
 			queue_free()
 	if lifetime <0:

--- a/scripts/classes/objective.gd
+++ b/scripts/classes/objective.gd
@@ -37,9 +37,6 @@ func update_collision_radius(range_collider: Area3D, radius: float):
 
 func _update_healthbar(healthbar: ProgressBar):
 	healthbar.value = health
-	if health <= 0:
-		health = 0
-		die()
 
 func target_in_attack_range(collider: Area3D):
 	var bodies = collider.get_overlapping_bodies()
@@ -53,10 +50,8 @@ func attack(entity: CharacterBody3D, _nav_agent: NavigationAgent3D):
 	is_attacking = true
 
 func take_damage(damage: float):
-	print_debug(damage)
 	var taken: float = armor / 100
 	taken = damage / (taken + 1)
-	print_debug(taken)
 	health -= taken
 	if health <= 0:
 		die()

--- a/scripts/classes/objective.gd
+++ b/scripts/classes/objective.gd
@@ -77,7 +77,10 @@ func finish_auto_attack(attack_timer: Timer, collider: Area3D):
 	var shot = projectile.instantiate()
 	shot.position = position
 	shot.target = target_entity
-	shot.damage = attack_damage
+	if !shot.target.is_in_group("Champion"):
+		shot.damage = attack_damage/10  # Reduced damage to non-champs
+	else:
+		shot.damage = attack_damage
 	get_node("Projectiles").add_child(shot, true)
 	init_auto_attack()
 
@@ -85,15 +88,9 @@ func set_target():
 	var bodies = $AttackArea.get_overlapping_bodies()
 	var target_found = false;
 	for body in bodies:
-		if body is CharacterBody3D and body.team != team and body.is_in_group("Champion"):
+		if body is CharacterBody3D and body.team != team:
 			target_entity = body
-			target_found = true;
-			#if body == target_entity:
-				#target_found = true;
-				#return;
-			#elif body.team:
-				#target_entity = body
-				#target_found = true;
+			target_found = true
 	if !target_found:
 		target_entity = null;
 		target_ray.hide()

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -72,21 +72,35 @@ func player_action(event):
 	var space = get_world_3d().direct_space_state
 	var params = PhysicsRayQueryParameters3D.create(from, to)
 	var result = space.intersect_ray(params)
-	# Move
-	if result and result.collider.is_in_group("ground"):
-		result.position.y += 1
-		var marker = MoveMarker.instantiate()
-		marker.position = result.position
-		get_node("/root").add_child(marker)
-		server_listener.rpc_id(get_multiplayer_authority(), "move_to", result.position)
-		#Player.MoveTo(result.position)
-	# Attack
 	if !result: return
+	# Move
+	if result.collider.is_in_group("ground"):
+		_player_action_move(result)
+	# Attack
+	_player_action_attack(result)
+
+
+func _player_action_attack(result):
 	var collider_groups = result.collider.get_groups()
 	for group in collider_groups:
 		if group not in ["Objective", "Minion", "Champion"]: continue
 		server_listener.rpc_id(get_multiplayer_authority(), "target", result.collider.name)
 		break
+	# To account for hitting Navmeshes, we check the parent of the target as well
+	var parent_collider_groups = result.collider.get_parent().get_groups()
+	for group in parent_collider_groups:
+		if group not in ["Objective", "Minion", "Champion"]: continue
+		server_listener.rpc_id(get_multiplayer_authority(), "target", result.collider.get_parent().name)
+		break
+
+
+func _player_action_move(result):
+		result.position.y += 1
+		var marker = MoveMarker.instantiate()
+		marker.position = result.position
+		get_node("/root").add_child(marker)
+		server_listener.rpc_id(get_multiplayer_authority(), "move_to", result.position)
+
 
 func center_camera(playerid):
 	camera_target_position = get_target_position(playerid)

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -81,18 +81,13 @@ func player_action(event):
 		server_listener.rpc_id(get_multiplayer_authority(), "move_to", result.position)
 		#Player.MoveTo(result.position)
 	# Attack
-	if result and result.collider.is_in_group("Objective"):
+	if !result: return
+	var collider_groups = result.collider.get_groups()
+	for group in collider_groups:
+		if group not in ["Objective", "Minion", "Champion"]: continue
 		server_listener.rpc_id(get_multiplayer_authority(), "target", result.collider.name)
-		return
-	if result and result.collider.is_in_group("Minion"):
-		server_listener.rpc_id(get_multiplayer_authority(), "target", result.collider.name)
-		return
-	if result and result.collider.is_in_group("Champion"):
-		server_listener.rpc_id(get_multiplayer_authority(), "target", result.collider.name)
-		return
-	if result and result.collider is CharacterBody3D:
-		server_listener.rpc_id(get_multiplayer_authority(), "target", result.collider.pid)
-		
+		break
+
 func center_camera(playerid):
 	camera_target_position = get_target_position(playerid)
 


### PR DESCRIPTION
- Turrets can now target Minions (fixing half of #56 )
- Fixed bug that caused players to be unable to attack towers (the raycast kept hitting the navmesh, not the turret itself)
- Optimized the player_action method (removed some repeated code, cleaned it up and made it more modular)
- Fixed bug where abilities would damage objectives, this is no longer the case (that would be broken and op)
- Implemented a very basic rule for turrets to damage minions less than champions, numbers need to be tweaked but the mechanic is there