### PR TITLE
Some more camera tweaks, framerate-related improvements

### DIFF
--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -104,7 +104,7 @@ func _process(delta):
 	detect_ability_use()
 	
 	# update the camera position using lerp
-	position = position.lerp(camera_target_position, delta * Config.cam_speed)
+	position = position.lerp(camera_target_position, 5 * delta)
 
 
 func detect_ability_use() -> void:
@@ -154,7 +154,7 @@ func camera_movement_handler() -> void:
 			cam_delta += Vector3(mouse_delta.x, 0, mouse_delta.y) * Config.cam_pan_sensitivity
 		
 		# Apply camera movement
-		camera_target_position += cam_delta
+		camera_target_position += cam_delta * get_process_delta_time() * Config.cam_speed
 	
 	# Zoom
 	if Input.is_action_just_pressed("player_zoomin"):

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -154,8 +154,7 @@ func camera_movement_handler() -> void:
 			cam_delta += Vector3(mouse_delta.x, 0, mouse_delta.y) * Config.cam_pan_sensitivity
 		
 		# Apply camera movement
-		if cam_delta != Vector3.ZERO:
-			camera_target_position += cam_delta
+		camera_target_position += cam_delta
 	
 	# Zoom
 	if Input.is_action_just_pressed("player_zoomin"):


### PR DESCRIPTION
I noticed an issue that running the game at a high FPS made the camera move way too fast, and the Config control for camera speed was not actually linked to the speed of the camera, but instead in the weight of the lerp. Did some testing and got a base value for the lerp that looks good in the FPS's I tested (60, 90, 240) when multiplied by the delta, seems consistent to me.

Could probably use a new config slider to adjust the lerp base value but to be honest I don't want to mess with that.